### PR TITLE
template-sync.yml: remove issues: read permission

### DIFF
--- a/.github/workflows/template-sync.yml
+++ b/.github/workflows/template-sync.yml
@@ -6,7 +6,6 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  issues: read
 
 jobs:
     repo-sync:


### PR DESCRIPTION
## Description
The `template-sync.yml` workflow was requesting the `issues: read` permission that is not being utilized causing downstream errors in calling workflows that do not provide the aforementioned permission.

## Related issue
[HDM-208](https://hashicorp.atlassian.net/browse/HDM-208)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How has this been tested?
- Removed the `issues: read` permission.
- Manually ran a workflow from branch.
- Successful [workflow run](https://github.com/hashicorp/terraform-aws-terraform-enterprise-eks-hvd/actions/runs/20824647169) and [PR](https://github.com/hashicorp/terraform-aws-terraform-enterprise-eks-hvd/pull/37) created.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Additional notes
N/A


[HDM-208]: https://hashicorp.atlassian.net/browse/HDM-208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ